### PR TITLE
feat: add Nix flake for reproducible builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772624091,
+        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,161 @@
+{
+  description = "FlashKraft — Lightning-fast OS image writer (GUI + TUI)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        commonMeta = with pkgs.lib; {
+          homepage = "https://github.com/sorinirimies/flashkraft";
+          license = licenses.mit;
+          maintainers = [ ];
+        };
+
+        linuxBuildInputs = with pkgs; [
+          vulkan-loader
+          wayland
+          wayland-protocols
+          libxkbcommon
+          fontconfig
+          freetype
+          libGL
+          xorg.libX11
+          xorg.libXcursor
+          xorg.libXrandr
+          xorg.libXi
+          gtk3
+        ];
+
+        linuxRuntimeLibs = with pkgs; [
+          vulkan-loader
+          wayland
+          libxkbcommon
+          libGL
+        ];
+
+        darwinBuildInputs = with pkgs.darwin.apple_sdk.frameworks; [
+          AppKit
+          CoreFoundation
+          CoreGraphics
+          Metal
+          QuartzCore
+        ];
+
+        flashkraft-gui = pkgs.rustPlatform.buildRustPackage {
+          pname = "flashkraft";
+          version = self.shortRev or self.dirtyShortRev or "dev";
+
+          src = pkgs.lib.cleanSource ./.;
+
+          cargoLock.lockFile = ./Cargo.lock;
+
+          # Tests require a real filesystem (file explorer tests fail in sandbox)
+          doCheck = false;
+
+          nativeBuildInputs = with pkgs;
+            [
+              pkg-config
+            ]
+            ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
+              wrapGAppsHook3
+            ];
+
+          buildInputs =
+            pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux linuxBuildInputs
+            ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin darwinBuildInputs;
+
+          cargoBuildFlags = [
+            "-p"
+            "flashkraft"
+          ];
+          cargoTestFlags = [
+            "-p"
+            "flashkraft"
+          ];
+
+          postFixup = pkgs.lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
+            wrapProgram "$out/bin/flashkraft" \
+              --prefix LD_LIBRARY_PATH : "${pkgs.lib.makeLibraryPath linuxRuntimeLibs}"
+          '';
+
+          meta = commonMeta // {
+            description = "FlashKraft — OS image writer desktop application (Iced GUI)";
+            mainProgram = "flashkraft";
+            platforms = with pkgs.lib.platforms; linux ++ darwin;
+          };
+        };
+
+        flashkraft-tui = pkgs.rustPlatform.buildRustPackage {
+          pname = "flashkraft-tui";
+          version = self.shortRev or self.dirtyShortRev or "dev";
+
+          src = pkgs.lib.cleanSource ./.;
+
+          cargoLock.lockFile = ./Cargo.lock;
+
+          doCheck = false;
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+
+          buildInputs =
+            pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin darwinBuildInputs;
+
+          cargoBuildFlags = [
+            "-p"
+            "flashkraft-tui"
+          ];
+          cargoTestFlags = [
+            "-p"
+            "flashkraft-tui"
+          ];
+
+          meta = commonMeta // {
+            description = "FlashKraft — OS image writer terminal application (Ratatui TUI)";
+            mainProgram = "flashkraft-tui";
+            platforms = with pkgs.lib.platforms; linux ++ darwin;
+          };
+        };
+      in
+      {
+        packages = {
+          default = flashkraft-gui;
+          inherit flashkraft-gui flashkraft-tui;
+        };
+
+        apps = {
+          default = flake-utils.lib.mkApp {
+            drv = flashkraft-gui;
+            name = "flashkraft";
+          };
+          flashkraft-tui = flake-utils.lib.mkApp {
+            drv = flashkraft-tui;
+            name = "flashkraft-tui";
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ flashkraft-gui ];
+
+          packages = with pkgs; [
+            rust-analyzer
+            rustfmt
+            clippy
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Before adding my AI-generated PR description, I want to thank you for this project.
I was looking for a modern TUI to flash my latest openclaw projects on rpi devices and thankfully ChatGPT mentioned your project. I also noticed that you are from our region, so I want to support the locals. Keep up the great work!

## Summary

- Add `flake.nix` with separate packages for GUI (`flashkraft-gui`) and TUI (`flashkraft-tui`)
- Cross-platform support for Linux and macOS with appropriate dependencies
- Runtime library wrapping (Vulkan, Wayland, libxkbcommon, libGL) for the WGPU-based GUI
- Dev shell with rust-analyzer, rustfmt, and clippy

## Usage

```bash
# Build and run the GUI
nix run github:sorinirimies/flashkraft

# Build and run the TUI
nix run github:sorinirimies/flashkraft#flashkraft-tui

# Enter dev shell
nix develop github:sorinirimies/flashkraft
```

## Test plan

- [x] `nix build .#flashkraft-gui` builds successfully on Linux
- [x] `nix build .#flashkraft-tui` builds successfully on Linux
- [ ] macOS build (untested — Darwin inputs included based on framework requirements)